### PR TITLE
Fix random 403 errors

### DIFF
--- a/src/vazkii/cmpdl/CMPDL.java
+++ b/src/vazkii/cmpdl/CMPDL.java
@@ -270,9 +270,11 @@ public final class CMPDL {
 	public static String getLocationHeader(String location) throws IOException, URISyntaxException {
 		URI uri = new URI(location);
 		HttpURLConnection connection = null;
+		String userAgent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/53.0.2785.143 Chrome/53.0.2785.143 Safari/537.36";
 		for(;;) {
 			URL url = uri.toURL();
 			connection = (HttpURLConnection) url.openConnection();
+			connection.setRequestProperty("User-Agent", userAgent);
 			connection.setInstanceFollowRedirects(false);
 			String redirectLocation = connection.getHeaderField("Location");
 			if(redirectLocation == null) 


### PR DESCRIPTION
It seems that curse looks at the user agent (at least some of the
time) and providing a user agent prevents the 403.