### PR TITLE
UI changes, add logging for missing modpacks and failed overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ Licensed under the [WTFPL](http://www.wtfpl.net/). Have fun.
  * Download CMPDL on the [Releases](https://github.com/Vazkii/CMPDL/releases) page. Run it.
  * Find the pack you want. We'll use [Proton](https://minecraft.curseforge.com/projects/proton) as an example.
  * Copy the URL of the project home on CurseForge. It should look like the one on the last point. Paste this URL on the "Modpack URL" field on CMPDL.
+ * To specify a version of the modpack, enter that version in the "Curse File ID" field
  * Press Download and wait.
  * Copy your modpack files over to wherever you want them.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@
 Downloads modpacks from curse, given a URL. Experimental. Requires gson and zip4j.
 
 Licensed under the [WTFPL](http://www.wtfpl.net/). Have fun.
+
+## Usage Instructions
+ 
+ * Download CMPDL on the [Releases](https://github.com/Vazkii/CMPDL/releases) page. Run it.
+ * Find the pack you want. We'll use [Proton](https://minecraft.curseforge.com/projects/proton) as an example.
+ * Copy the URL of the project home on CurseForge. It should look like the one on the last point. Paste this URL on the "Modpack URL" field on CMPDL.
+ * Press Download and wait.
+ * Copy your modpack files over to wherever you want them.

--- a/src/vazkii/cmpdl/CMPDL.java
+++ b/src/vazkii/cmpdl/CMPDL.java
@@ -34,15 +34,18 @@ public final class CMPDL {
 	public static void main(String[] args) {
 		if(args.length > 0) {
 			String url = args[0];
+			String version = "latest";
+			if (args.length > 1)
+				version = args[1];
 			try {
-				downloadFromURL(url);
+				downloadFromURL(url, version);
 			} catch(Exception e) {
 				throw new RuntimeException(e);
 			}
 		} else Interface.openInterface();
 	}
 
-	public static void downloadFromURL(String url) throws Exception {
+	public static void downloadFromURL(String url, String version) throws Exception {
 		if(downloading)
 			return;
 
@@ -54,7 +57,16 @@ public final class CMPDL {
 		if(packUrl.endsWith("/"))
 			packUrl = packUrl.replaceAll(".$", "");
 
-		String fileUrl = packUrl + "/files/latest";
+		String packVersion = version;
+		if(version == null || version.isEmpty())
+			packVersion = "latest";
+
+		String fileUrl;
+		if (packVersion == "latest")
+			fileUrl = packUrl + "/files/latest";
+		else
+			fileUrl = packUrl + "/files/" + packVersion + "/download";
+
 		String finalUrl = getLocationHeader(fileUrl);
 		log("URLs: " + fileUrl + " " + finalUrl);
 		Matcher matcher = FILE_NAME_URL_PATTERN.matcher(finalUrl);
@@ -108,7 +120,7 @@ public final class CMPDL {
 
 		String zipName = filename;
 		if(!zipName.endsWith(".zip"))
-			zipName = zipName + ".zip";		
+			zipName = zipName + ".zip";
 
 		String retPath = retDir.getAbsolutePath();
 		retDir.deleteOnExit();
@@ -166,7 +178,7 @@ public final class CMPDL {
 		int left = total;
 		for(Manifest.FileData f : manifest.files) {
 			left--;
-			downloadFile(f, modsDir, left, total); 
+			downloadFile(f, modsDir, left, total);
 		}
 
 		log("Mod downloads complete");
@@ -275,12 +287,12 @@ public final class CMPDL {
 			connection = (HttpURLConnection) url.openConnection();
 			connection.setInstanceFollowRedirects(false);
 			String redirectLocation = connection.getHeaderField("Location");
-			if(redirectLocation == null) 
+			if(redirectLocation == null)
 				break;
 
 			redirectLocation = redirectLocation.replaceAll("\\[", "%5B");
 			redirectLocation = redirectLocation.replaceAll("\\]", "%5D");
-			
+
 			if(redirectLocation.startsWith("/"))
 				uri = new URI(uri.getScheme(), uri.getHost(), redirectLocation, uri.getFragment());
 			else uri = new URI(redirectLocation);
@@ -304,7 +316,7 @@ public final class CMPDL {
 
 	public static void log(String s) {
 		Interface.addLogLine(s);
-		System.out.println(s); 
+		System.out.println(s);
 	}
 
 	private CMPDL() {}

--- a/src/vazkii/cmpdl/Interface.java
+++ b/src/vazkii/cmpdl/Interface.java
@@ -46,9 +46,11 @@ public class Interface {
 
 		JPanel panel;
 		JButton downloadButton;
-		JLabel label;
+		JLabel urlLabel;
+		JLabel versionLabel;
 		JScrollPane scrollPane;
 		JTextField urlField;
+		JTextField versionField;
 		JTextArea logArea;
 		JLabel currentStatus;
 
@@ -58,8 +60,10 @@ public class Interface {
 
 			panel = new JPanel();
 			downloadButton = new JButton("Download");
-			label = new JLabel("Modpack URL");
+			urlLabel = new JLabel("Modpack URL");
 			urlField = new JTextField("", 54);
+			versionLabel = new JLabel("Curse File ID");
+			versionField = new JTextField("latest", 54);
 
 			logArea = new JTextArea(34, 68);
 			logArea.setBackground(Color.WHITE);
@@ -71,8 +75,10 @@ public class Interface {
 
 			currentStatus = new JLabel("Idle", SwingConstants.LEFT);
 
-			panel.add(label);
+			panel.add(urlLabel);
 			panel.add(urlField);
+			panel.add(versionLabel);
+			panel.add(versionField);
 			panel.add(downloadButton);
 			panel.add(scrollPane);
 			panel.add(currentStatus);
@@ -81,6 +87,7 @@ public class Interface {
 			downloadButton.requestFocus();
 			downloadButton.addActionListener(this);
 			urlField.addKeyListener(this);
+			versionField.addKeyListener(this);
 
 			addWindowListener(new WindowAdapter() {
 				@Override
@@ -108,11 +115,12 @@ public class Interface {
 		@Override
 		public void actionPerformed(ActionEvent e) {
 			String url = urlField.getText();
+			String version = versionField.getText();
 			if(url != null && !url.isEmpty() && !CMPDL.downloading)
-				operatorThread = new OperatorThread(url);
+				operatorThread = new OperatorThread(url, version);
 		}
 
-		@Override public void keyPressed(KeyEvent e) {  }
+		@Override public void keyPressed(KeyEvent e) {	}
 		@Override public void keyReleased(KeyEvent e) { }
 	}
 

--- a/src/vazkii/cmpdl/OperatorThread.java
+++ b/src/vazkii/cmpdl/OperatorThread.java
@@ -3,9 +3,11 @@ package vazkii.cmpdl;
 public class OperatorThread extends Thread {
 
 	String url;
+	String version;
 
-	public OperatorThread(String url) {
+	public OperatorThread(String url, String version) {
 		this.url = url;
+		this.version = version;
 		setName("Operator");
 		setDaemon(true);
 		start();
@@ -14,7 +16,7 @@ public class OperatorThread extends Thread {
 	@Override
 	public void run() {
 		try {
-			CMPDL.downloadFromURL(url);
+			CMPDL.downloadFromURL(url, version);
 		} catch(Exception ex) {
 			Interface.addLogLine("Error: " + ex.getLocalizedMessage());
 			for(StackTraceElement e : ex.getStackTrace())


### PR DESCRIPTION
NOTE: Includes ability to specify modpack version from [boatrite's pull request](https://github.com/Vazkii/CMPDL/pull/9) as this was extremely helpful for me.  Also while doing this, didn't realize you had a fix for 403 errors (User-Agent header); removed my solution but it's probably in the history now.

A lot of changes for one pull request - if you need me to break any out let me know.

Logging changes to highlight issues:
- Log missing modpacks at the end of the download process to make it easier to detect/correct
- Log errors copying overrides

A few changes to the UI:
- Ability to resize for readability on long log lines (default size not changed)
- Added button to clear the log area
- Formatting changes for boatrite's pull request
- Fix for issue with UI on Arch Linux with Gnome3 cutting off log text
Before:
![Before](https://cloud.githubusercontent.com/assets/3083329/25569941/23b03bcc-2de5-11e7-95f6-5fdd55a75ecd.png)
After:
![After](https://cloud.githubusercontent.com/assets/3083329/25569942/29347afe-2de5-11e7-92a7-bb14bb589db8.png)

