### PR TITLE
Update to work again after curseforge urls changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Curse Modpack Downloader**
 
-Downloads modpacks from curse, given a URL. Experimental. Requires gson and zip4j.
+Downloads modpacks from curse, given a URL and Curse File ID. Experimental. Requires gson (2.8.x) and zip4j (1.3.2).
 
 Licensed under the [WTFPL](http://www.wtfpl.net/). Have fun.
 
@@ -10,7 +10,7 @@ Licensed under the [WTFPL](http://www.wtfpl.net/). Have fun.
  
  * Download CMPDL on the [Releases](https://github.com/Vazkii/CMPDL/releases) page. Run it.
  * Find the pack you want. We'll use [Proton](https://minecraft.curseforge.com/projects/proton) as an example.
- * Copy the URL of the project home on CurseForge. It should look like the one on the last point. Paste this URL on the "Modpack URL" field on CMPDL. (you can also choose a local modpack file)
- * To specify a version of the modpack, enter that version in the "Curse File ID" field
+ * Copy the URL of the project home on CurseForge. It should look like the one on the last point. Paste this URL on the "Modpack URL" field on CMPDL. (you can also choose a local modpack zip file)
+ * Specify a version of the modpack, enter that version in the "Curse File ID" field. You can find the ID at the end of the urls under "Recent Files" in the sidebar on the project page or in the project's "Files" tab.
  * Press Download and wait.
  * Copy your modpack files over to wherever you want them.

--- a/src/vazkii/cmpdl/CMPDL.java
+++ b/src/vazkii/cmpdl/CMPDL.java
@@ -55,12 +55,22 @@ public final class CMPDL {
 		if(downloading)
 			return;
 
-		if(url.contains("feed-the-beast.com") && version.equals("latest")) {
+		if(url.contains("feed-the-beast.com") && (version.equals("latest") || version == null || version.isEmpty())) {
 			log("WARNING: For modpacks hosted in the FTB site, you need to provide a version, \"latest\" will not work!");
 			log("To find the version number to insert in the Curse File ID field, click the latest file on the sidebar on the right of the modpack's page.");
 			log("The number you need to input is the number at the end of the URL.");
 			log("For example, if you wanted to download https://www.feed-the-beast.com/projects/ftb-presents-skyfactory-3/files/2390075");
 			log("Then you would use 2390075 as the Curse File ID. Do not change the Modpack URL. Change that and click Download again to continue.");
+			Interface.setStatus("Awaiting Further Input");
+			return;
+		}
+		
+		if(url.contains("curseforge.com") && (version.equals("latest") || version == null || version.isEmpty())) {
+			log("WARNING: packversion \"latest\" is currently unsupported as curseforge have changed their url format.");
+			log("To find the version number to insert in the Curse File ID field, check the url of the file on the modpack's \"files\" page.");
+			log("The number you need to input is the number at the end of the URL.");
+			log("For example, if you wanted to download https://www.curseforge.com/minecraft/modpacks/crucial/files/2732998");
+			log("Then you would use 2732998 as the Curse File ID. Do not change the Modpack URL. Change that and click Download again to continue.");
 			Interface.setStatus("Awaiting Further Input");
 			return;
 		}
@@ -77,14 +87,9 @@ public final class CMPDL {
 			packUrl = packUrl.replaceAll(".$", "");
 
 		String packVersion = version;
-		if(version == null || version.isEmpty())
-			packVersion = "latest";
 
 		String fileUrl;
-		if (packVersion.equals("latest"))
-			fileUrl = packUrl + "/files/latest";
-		else
-			fileUrl = packUrl + "/files/" + packVersion + "/download";
+		fileUrl = packUrl + "/download/" + packVersion + "/file";
 
 		String finalUrl = getLocationHeader(fileUrl);
 		log("File URL: " + fileUrl);
@@ -341,7 +346,7 @@ public final class CMPDL {
 
 		String projectUrl = getLocationHeader(baseUrl);
 		projectUrl = projectUrl.replaceAll("\\?cookieTest=1", "");
-		String fileDlUrl = projectUrl + "/files/" + file.fileID + "/download";
+		String fileDlUrl = projectUrl + "/download/" + file.fileID + "/file";
 		log("File download URL is " + fileDlUrl);
 
 		String finalUrl = getLocationHeader(fileDlUrl);

--- a/src/vazkii/cmpdl/Interface.java
+++ b/src/vazkii/cmpdl/Interface.java
@@ -135,7 +135,7 @@ public class Interface {
 			urlLabel = new JLabel("Modpack URL :");
 			urlField = new JTextField("", 54);
 			versionLabel = new JLabel("Curse File ID :");
-			versionField = new JTextField("latest", 20);
+			versionField = new JTextField("", 20);
 
 			logArea = new JTextArea(34, 68);
 			logArea.setBackground(Color.WHITE);


### PR DESCRIPTION
Curseforge's urls have changed and don't seem to support the file ID "latest" anymore. I adjusted the urls to work again and added a new warning similar to the one for FTB packs prompting the user to grab the modpack File ID.